### PR TITLE
Added item ID to metadata

### DIFF
--- a/src/SharefileAdapter.php
+++ b/src/SharefileAdapter.php
@@ -423,6 +423,7 @@ class SharefileAdapter extends AbstractAdapter
                 'size' => $item['FileSizeBytes'],
                 'contents' =>  ! empty($contents) ? $contents : false,
                 'stream' => ! empty($stream) ? $stream : false,
+                'id' => isset($item['Id']) ? $item['Id'] : false,
             ],
             $this->returnShareFileItem ? ['sharefile_item' => $item] : []
         );

--- a/tests/SharefileAdapterTest.php
+++ b/tests/SharefileAdapterTest.php
@@ -93,7 +93,9 @@ class SharefileAdapterTest extends TestCase
 
         $result = $this->adapter->{$method}($filename);
 
-        $expectedResult = $this->calculateExpectedMetadata($filename);
+        $expectedResult = $this->calculateExpectedMetadata($filename, [
+			'id' => false,
+		]);
 
         $this->assertSame($expectedResult, $result);
     }
@@ -148,6 +150,7 @@ class SharefileAdapterTest extends TestCase
 
         $expectedResult = $this->calculateExpectedMetadata($filename, [
             'contents' => $contents,
+			'id' => '1',
          ]);
         $result = $this->adapter->read($filename);
         $this->assertsame($expectedResult, $result);
@@ -187,7 +190,9 @@ class SharefileAdapterTest extends TestCase
         $this->assertSame($contents, stream_get_contents($result['stream']));
 
         $result['stream'] = false;
-        $expectedResult = $this->calculateExpectedMetadata($filename);
+        $expectedResult = $this->calculateExpectedMetadata($filename, [
+			'id' => '2',
+		]);
         $this->assertsame($expectedResult, $result);
     }
 
@@ -240,8 +245,11 @@ class SharefileAdapterTest extends TestCase
             $this->calculateExpectedMetadata($directory.'/folder', [
                 'mimetype' => 'inode/directory',
                 'type' => 'dir',
+				'id' => '2'
             ]),
-            $this->calculateExpectedMetadata($directory.'/folder/file.txt'),
+            $this->calculateExpectedMetadata($directory.'/folder/file.txt', [
+				'id' => '3'
+			]),
         ];
 
         $this->assertsame($expectedResult, $result);
@@ -283,6 +291,7 @@ class SharefileAdapterTest extends TestCase
 
         $expectedResult = $this->calculateExpectedMetadata($filename, [
             'contents' => $contents,
+			'id' => false,
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -323,7 +332,9 @@ class SharefileAdapterTest extends TestCase
         fseek($resource, 0);
         fwrite($resource, $contents);
 
-        $expectedResult = $this->calculateExpectedMetadata($filename);
+        $expectedResult = $this->calculateExpectedMetadata($filename, [
+			'id' => false,
+		]);
 
         $this->assertSame($expectedResult, $this->adapter->writeStream($filename, $resource, new Config()));
         $this->assertSame($expectedResult, $this->adapter->updateStream($filename, $resource, new Config()));
@@ -582,7 +593,9 @@ class SharefileAdapterTest extends TestCase
 
         $result = $this->adapter->createDir($path);
 
-        $expectedResult = $this->calculateExpectedMetadata($path);
+        $expectedResult = $this->calculateExpectedMetadata($path, [
+			'id' => false,
+		]);
 
         $this->assertSame($result, $expectedResult);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use Sabre\DAV\Exception;
 use Sabre\HTTP\HttpException;
 use Kapersoft\Sharefile\Client;
 use Sabre\DAV\Client as WebDAVClient;
-use Kapersoft\FlysystemSharefile\sharefileAdapter;
+use Kapersoft\FlysystemSharefile\SharefileAdapter;
 use PHPUnit\Framework\TestCase as PHPUnit_Framework_Testcase;
 
 /**


### PR DESCRIPTION
It can be useful to access the unique ShareFile item ID for files/folders from an app utilizing FlySystem. For example this ID can be used to create a simple and secure link to a file/folder. Therefore it has been added to the FlySystem metadata array as an additional feature.